### PR TITLE
Seek functionality

### DIFF
--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -304,6 +304,7 @@ void ofxGstVideoSyncPlayer::update()
             else if( m.getAddress() == "/pause" && !m_isMaster ){
                 m_pos = m.getArgAsInt64(0);
                 ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> PAUSE " << std::endl;
+                ofLogNotice("client pause seek to position", ofToString(m_pos));
 
                 gst_element_set_state(m_gstPipeline, GST_STATE_PAUSED);
                 gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -401,8 +401,8 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
       ofLogWarning("failed to seek");
   } else {
     sendSeekMsg(time_nanoseconds);
-    gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
-    ofLogNotice("done seeking");
+    // gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
+    // ofLogNotice("done seeking");
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -403,6 +403,8 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   sendSeekMsg(time_nanoseconds);
   ofLogNotice("clock time before seek", ofToString(m_gstClockTime));
 
+  gst_element_query_position(GST_ELEMENT(m_gstPipeline),GST_FORMAT_TIME,&m_pos);
+
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
   if (!gst_element_seek_simple(m_gstPipeline, GST_FORMAT_TIME, _flags, time_nanoseconds)) {

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -412,7 +412,11 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
     gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
     setMasterClock();
     ofLogNotice("clock time setMasterClock()", ofToString(m_gstClockTime));
-    // sendPlayMsg();
+
+    gst_element_set_state(m_gstPipeline, GST_STATE_PLAYING);
+    gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
+
+    sendPlayMsg();
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -383,7 +383,10 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   gint64 time_nanoseconds = time_ms * pow(10, 6);
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
-  if (!gst_element_seek_simple(m_gstPipeline, GST_FORMAT_TIME, _flags, time_nanoseconds));
+  if (!gst_element_seek_simple(m_gstPipeline, GST_FORMAT_TIME, _flags, time_nanoseconds)) {
+      ofLogWarning("failed to seek");
+  }
+
 
 }
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -550,7 +550,7 @@ void ofxGstVideoSyncPlayer::sendPauseMsg(){
         m_oscSender->setup(_client.first, _client.second);
         ofxOscMessage m;
         m.setAddress("/pause");
-        m.addInt64Arg(m_pos + 1000000000000);
+        m.addInt64Arg(m_pos);
         m.setRemoteEndpoint(_client.first, _client.second);
         m_oscSender->sendMessage(m,false);
     }
@@ -565,7 +565,7 @@ void ofxGstVideoSyncPlayer::sendPlayMsg()
         m_oscSender->setup(_client.first, _client.second);
         ofxOscMessage m;
         m.setAddress("/play");
-        m.addInt64Arg(m_gstClockTime);
+        m.addInt64Arg(m_gstClockTime + 967547000);
         m.setRemoteEndpoint(_client.first, _client.second);
         m_oscSender->sendMessage(m,false);
     }

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -345,13 +345,12 @@ void ofxGstVideoSyncPlayer::update()
 
                 GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
-                ///> Set the slave clock and base_time.
-                setClientClock(m.getArgAsInt64(0));
-
                 if( !gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, _flags, newPosition )) {
                         ofLogWarning () << "Resync seek failed" << std::endl;
                 }
 
+                ///> Set the slave clock and base_time.
+                setClientClock(m.getArgAsInt64(0));
             }
             else if( m.getAddress() == "/eos" && !m_isMaster ){
                 ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> EOS " << std::endl;
@@ -403,8 +402,9 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   } else {
     gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
     ofLogNotice("done seeking");
-    gst_element_query_position(GST_ELEMENT(m_gstPipeline),GST_FORMAT_TIME,&m_pos);
-    sendSeekMsg(m_pos);
+    setMasterClock();
+
+    sendSeekMsg(time_nanoseconds);
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -340,7 +340,7 @@ void ofxGstVideoSyncPlayer::update()
             }
             else if( m.getAddress() == "/seek" && !m_isMaster ){
 
-              m_pos = m.getArgAsInt64(0);
+              m_pos = m.getArgAsInt64(1);
               ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> SEEK (PAUSE) to" << ofToString(m_pos) << std::endl;
 
               gst_element_set_state(m_gstPipeline, GST_STATE_PAUSED);

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -400,10 +400,10 @@ void ofxGstVideoSyncPlayer::play()
 
 void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   gint64 time_nanoseconds = time_ms * pow(10, 6);
+
   sendSeekMsg(time_nanoseconds);
   ofLogNotice("clock time before seek", ofToString(m_gstClockTime));
 
-  gst_element_query_position(GST_ELEMENT(m_gstPipeline),GST_FORMAT_TIME,&m_pos);
 
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
@@ -411,13 +411,10 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
       ofLogWarning("failed to seek");
   } else {
     GstState state;
-    gst_element_get_state(m_gstPipeline, &state, NULL, GST_CLOCK_TIME_NONE);
-    if (state == GST_STATE_PLAYING) {
-      ofLogNotice("clock time after seek", ofToString(m_gstClockTime));
-      setMasterClock();
-      ofLogNotice("clock time setMasterClock()", ofToString(m_gstClockTime));
-      sendPlayMsg();
-    }
+    gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
+    ofLogNotice("clock time setMasterClock()", ofToString(m_gstClockTime));
+    sendPlayMsg();
+    setMasterClock();
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -343,9 +343,9 @@ void ofxGstVideoSyncPlayer::update()
                 gint64 newPosition = m.getArgAsInt64(1);
                 ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> SEEK to " << ofToString(newPosition) << std::endl;
 
-                // GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
+                GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
-                if( !gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, GST_SEEK_FLAG_ACCURATE, newPosition )) {
+                if( !gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, _flags, newPosition )) {
                         ofLogWarning () << "Resync seek failed" << std::endl;
                 }
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -402,9 +402,9 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   } else {
     gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
     ofLogNotice("done seeking");
-    setMasterClock();
 
     sendSeekMsg(time_nanoseconds);
+    setMasterClock();
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -399,7 +399,7 @@ void ofxGstVideoSyncPlayer::play()
 void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   gint64 time_nanoseconds = time_ms * pow(10, 6);
   sendSeekMsg(time_nanoseconds);
-  // ofLogNotice("clock time before seek", ofToString(m_gstClockTime))
+  ofLogNotice("clock time before seek", ofToString(m_gstClockTime))
 
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
@@ -409,6 +409,7 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
     GstState state;
     gst_element_get_state(m_gstPipeline, &state, NULL, GST_CLOCK_TIME_NONE);
     if (state == GST_STATE_PLAYING) {
+      ofLogNotice("clock time after seek", ofToString(m_gstClockTime))
       setMasterClock();
       sendPlayMsg();
     }

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -292,7 +292,6 @@ void ofxGstVideoSyncPlayer::update()
 
                 ///> Set the base time of the slave network clock.
                 setClientClock((GstClockTime)m.getArgAsInt64(0));
-                ofLogNotice("new base time", ofToString(m.getArgAsInt64(0)));
 
                 ///> And start playing..
                 gst_element_set_state(m_gstPipeline, GST_STATE_PLAYING);
@@ -369,8 +368,7 @@ void ofxGstVideoSyncPlayer::update()
 
 void ofxGstVideoSyncPlayer::play()
 {
-    // if( !m_isMaster || !m_paused ) return;
-    if( !m_isMaster) return;
+    if( !m_isMaster || !m_paused ) return;
 
     setMasterClock();
 
@@ -398,10 +396,7 @@ void ofxGstVideoSyncPlayer::play()
 
 void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   gint64 time_nanoseconds = time_ms * pow(10, 6);
-
   sendSeekMsg(time_nanoseconds);
-  ofLogNotice("clock time before seek", ofToString(m_gstClockTime));
-
 
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
@@ -411,7 +406,6 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
     GstState state;
     gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
     setMasterClock();
-    ofLogNotice("clock time setMasterClock()", ofToString(m_gstClockTime));
 
     gst_element_set_state(m_gstPipeline, GST_STATE_PLAYING);
     gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -341,20 +341,15 @@ void ofxGstVideoSyncPlayer::update()
             else if( m.getAddress() == "/seek" && !m_isMaster ){
 
               m_pos = m.getArgAsInt64(0);
-              ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> PAUSE " << std::endl;
+              ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> SEEK (PAUSE) to" << ofToString(m_pos) << std::endl;
 
               gst_element_set_state(m_gstPipeline, GST_STATE_PAUSED);
               gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
 
-              ///> This needs more thinking but for now it gives acceptable results.
-              ///> When we pause, we seek to the position of the master when paused was called.
-              ///> If we dont do this there is a delay before the pipeline starts again i.e when hitting play() again after pause()..
-              ///> I m pretty sure this can be done just by adjusting the base_time based on the position but
-              ///> havent figured it out exactly yet..
               GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
               if( !gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, _flags, m_pos )) {
-                      ofLogWarning () << "Pausing seek failed" << std::endl;
+                      ofLogWarning () << "Seek failed" << std::endl;
               }
 
               m_paused = true;

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -412,9 +412,9 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   } else {
     GstState state;
     gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
-    ofLogNotice("clock time setMasterClock()", ofToString(m_gstClockTime));
-    sendPlayMsg();
     setMasterClock();
+    ofLogNotice("clock time setMasterClock()", ofToString(m_gstClockTime));
+    // sendPlayMsg();
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -387,6 +387,32 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
 
 }
 
+gint64 ofxGstVideoSyncPlayer::getPosition() {
+  gint64 pos;
+  if (gst_element_query_position (m_gstPipeline, GST_FORMAT_TIME, &pos)) {
+    return pos;
+  } else {
+    return 0;
+  }
+}
+
+unsigned long int ofxGstVideoSyncPlayer::getPositionMilliseconds() {
+  return getPosition() / pow(10, 6);
+}
+
+gint64 ofxGstVideoSyncPlayer::getDuration() {
+  gint64 len;
+  if (gst_element_query_duration(m_gstPipeline, GST_FORMAT_TIME, &len)) {
+    return len;
+  } else {
+    return 0;
+  }
+}
+
+unsigned long int ofxGstVideoSyncPlayer::getDurationMilliseconds() {
+  return getDuration() / pow(10, 6);
+}
+
 void ofxGstVideoSyncPlayer::setMasterClock()
 {
     if( !m_isMaster ) return;

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -379,12 +379,11 @@ void ofxGstVideoSyncPlayer::play()
 
 }
 
-void ofxGstVideoSyncPlayer::seek(long int position) {
+void ofxGstVideoSyncPlayer::seek(long int time_ms) {
+  gint64 time_nanoseconds = time_ms * pow(10, 6);
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
-  if (!gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, _flags, position)) {
-          ofLogWarning() << "Seek failed" << std::endl;
-  }
+  if (!gst_element_seek_simple(m_gstPipeline, GST_FORMAT_TIME, _flags, time_nanoseconds));
 
 }
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -343,19 +343,14 @@ void ofxGstVideoSyncPlayer::update()
                 gint64 newPosition = m.getArgAsInt64(1);
                 ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> SEEK to " << ofToString(newPosition) << std::endl;
 
-                GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
+                // GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
-                if( !gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, _flags, newPosition )) {
+                if( !gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, GST_SEEK_FLAG_ACCURATE, newPosition )) {
                         ofLogWarning () << "Resync seek failed" << std::endl;
                 }
 
                 ///> Set the slave clock and base_time.
                 setClientClock(m.getArgAsInt64(0));
-
-                ///> And start playing..
-                gst_element_set_state(m_gstPipeline, GST_STATE_PLAYING);
-                gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
-
             }
             else if( m.getAddress() == "/eos" && !m_isMaster ){
                 ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> EOS " << std::endl;
@@ -405,9 +400,10 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   if (!gst_element_seek_simple(m_gstPipeline, GST_FORMAT_TIME, _flags, time_nanoseconds)) {
       ofLogWarning("failed to seek");
   } else {
-    sendSeekMsg(time_nanoseconds);
-    // gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
-    // ofLogNotice("done seeking");
+    gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
+    ofLogNotice("done seeking");
+    gst_element_query_position(GST_ELEMENT(m_gstPipeline),GST_FORMAT_TIME,&m_pos);
+    sendSeekMsg(m_pos);
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -292,6 +292,7 @@ void ofxGstVideoSyncPlayer::update()
 
                 ///> Set the base time of the slave network clock.
                 setClientClock(m.getArgAsInt64(0));
+                ofLogNotice("new base time", ofToString(m.getArgAsInt64(0)));
 
                 ///> And start playing..
                 gst_element_set_state(m_gstPipeline, GST_STATE_PLAYING);
@@ -399,7 +400,7 @@ void ofxGstVideoSyncPlayer::play()
 void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   gint64 time_nanoseconds = time_ms * pow(10, 6);
   sendSeekMsg(time_nanoseconds);
-  ofLogNotice("clock time before seek", ofToString(m_gstClockTime))
+  ofLogNotice("clock time before seek", ofToString(m_gstClockTime));
 
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
@@ -409,8 +410,9 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
     GstState state;
     gst_element_get_state(m_gstPipeline, &state, NULL, GST_CLOCK_TIME_NONE);
     if (state == GST_STATE_PLAYING) {
-      ofLogNotice("clock time after seek", ofToString(m_gstClockTime))
+      ofLogNotice("clock time after seek", ofToString(m_gstClockTime));
       setMasterClock();
+      ofLogNotice("clock time setMasterClock()", ofToString(m_gstClockTime));
       sendPlayMsg();
     }
   }

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -345,12 +345,13 @@ void ofxGstVideoSyncPlayer::update()
 
                 GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
+                ///> Set the slave clock and base_time.
+                setClientClock(m.getArgAsInt64(0));
+
                 if( !gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, _flags, newPosition )) {
                         ofLogWarning () << "Resync seek failed" << std::endl;
                 }
 
-                ///> Set the slave clock and base_time.
-                setClientClock(m.getArgAsInt64(0));
             }
             else if( m.getAddress() == "/eos" && !m_isMaster ){
                 ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> EOS " << std::endl;

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -372,7 +372,8 @@ void ofxGstVideoSyncPlayer::update()
 
 void ofxGstVideoSyncPlayer::play()
 {
-    if( !m_isMaster || !m_paused ) return;
+    // if( !m_isMaster || !m_paused ) return;
+    if( !m_isMaster) return;
 
     setMasterClock();
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -351,6 +351,11 @@ void ofxGstVideoSyncPlayer::update()
 
                 ///> Set the slave clock and base_time.
                 setClientClock(m.getArgAsInt64(0));
+
+                ///> And start playing..
+                gst_element_set_state(m_gstPipeline, GST_STATE_PLAYING);
+                gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
+
             }
             else if( m.getAddress() == "/eos" && !m_isMaster ){
                 ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> EOS " << std::endl;

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -345,9 +345,6 @@ void ofxGstVideoSyncPlayer::update()
               m_pos = m.getArgAsInt64(1);
               ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> SEEK (PAUSE) to" << ofToString(m_pos) << std::endl;
 
-              gst_element_set_state(m_gstPipeline, GST_STATE_PAUSED);
-              gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
-
               GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
               if( !gst_element_seek_simple (m_gstPipeline, GST_FORMAT_TIME, _flags, m_pos )) {

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -416,16 +416,14 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   if (!gst_element_seek_simple(m_gstPipeline, GST_FORMAT_TIME, _flags, time_nanoseconds)) {
       ofLogWarning("failed to seek");
   } else {
-    sendSeekMsg(time_nanoseconds);
+    // sendSeekMsg(time_nanoseconds);
+    sendPauseMsg();
     GstState state;
     gst_element_get_state(m_gstPipeline, &state, NULL, GST_CLOCK_TIME_NONE);
     if (state == GST_STATE_PLAYING) {
       uint64_t elapsed = ofGetElapsedTimeMicros() - t1;
-      ofLogNotice("m_gstClockTime after seek", ofToString(m_gstClockTime));
-      ofLogNotice("done seeking after", ofToString(elapsed));
       setMasterClock();
-      ofLogNotice("m_gstClockTime after setMasterClock", ofToString(m_gstClockTime));
-
+      sendPlayMsg();
     }
   }
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -291,7 +291,7 @@ void ofxGstVideoSyncPlayer::update()
                 ofLogVerbose("ofxGstVideoSyncPlayer") << " CLIENT ---> PLAY " << std::endl;
 
                 ///> Set the base time of the slave network clock.
-                setClientClock(m.getArgAsInt64(0));
+                setClientClock((GstClockTime)m.getArgAsInt64(0));
                 ofLogNotice("new base time", ofToString(m.getArgAsInt64(0)));
 
                 ///> And start playing..
@@ -576,8 +576,6 @@ void ofxGstVideoSyncPlayer::sendPlayMsg()
 void ofxGstVideoSyncPlayer::sendSeekMsg(gint64 newPosition)
 {
   if( !m_isMaster || !m_initialized || !m_oscSender ) return;
-
-  ofLogNotice("m_gstClockTime for sendSeekMsg", ofToString(m_gstClockTime));
 
   for( auto& _client : m_connectedClients ){
       ofLogVerbose("ofxGstVideoSyncPlayer") << " Sending SEEK to client : " << _client.first << " at port : " << _client.second << std::endl;

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -399,6 +399,7 @@ void ofxGstVideoSyncPlayer::play()
 void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   gint64 time_nanoseconds = time_ms * pow(10, 6);
   sendSeekMsg(time_nanoseconds);
+  // ofLogNotice("clock time before seek", ofToString(m_gstClockTime))
 
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
@@ -562,7 +563,7 @@ void ofxGstVideoSyncPlayer::sendPlayMsg()
         m_oscSender->setup(_client.first, _client.second);
         ofxOscMessage m;
         m.setAddress("/play");
-        m.addInt64Arg(m_gstClockTime + 47000);
+        m.addInt64Arg(m_gstClockTime);
         m.setRemoteEndpoint(_client.first, _client.second);
         m_oscSender->sendMessage(m,false);
     }

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -400,9 +400,9 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   if (!gst_element_seek_simple(m_gstPipeline, GST_FORMAT_TIME, _flags, time_nanoseconds)) {
       ofLogWarning("failed to seek");
   } else {
+    sendSeekMsg(time_nanoseconds);
     gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
     ofLogNotice("done seeking");
-    sendSeekMsg(time_nanoseconds);
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -349,6 +349,9 @@ void ofxGstVideoSyncPlayer::update()
                         ofLogWarning () << "Resync seek failed" << std::endl;
                 }
 
+                // first, wait for seek to complete
+                gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
+
                 ///> Get ready to start over..
                 gst_element_set_state(m_gstPipeline, GST_STATE_NULL);
                 gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);

--- a/src/ofxGstVideoSyncPlayer.cpp
+++ b/src/ofxGstVideoSyncPlayer.cpp
@@ -397,14 +397,20 @@ void ofxGstVideoSyncPlayer::seek(long int time_ms) {
   gint64 time_nanoseconds = time_ms * pow(10, 6);
   GstSeekFlags _flags = (GstSeekFlags) (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE);
 
+  uint64_t t1 = ofGetElapsedTimeMicros();
+
   if (!gst_element_seek_simple(m_gstPipeline, GST_FORMAT_TIME, _flags, time_nanoseconds)) {
       ofLogWarning("failed to seek");
   } else {
-    gst_element_get_state(m_gstPipeline, NULL, NULL, GST_CLOCK_TIME_NONE);
-    ofLogNotice("done seeking");
+    GstState state;
+    gst_element_get_state(m_gstPipeline, &state, NULL, GST_CLOCK_TIME_NONE);
+    if (state == GST_STATE_PLAYING) {
+      uint64_t elapsed = ofGetElapsedTimeMicros() - t1;
+      ofLogNotice("done seeking after", ofToString(elapsed));
+      setMasterClock();
+      sendSeekMsg(time_nanoseconds);
+    }
 
-    sendSeekMsg(time_nanoseconds);
-    setMasterClock();
   }
 
 

--- a/src/ofxGstVideoSyncPlayer.h
+++ b/src/ofxGstVideoSyncPlayer.h
@@ -22,7 +22,7 @@ class ofxGstVideoSyncPlayer{
         bool                            load( std::string _path );
         void                            play();
         void                            update();
-        void                            seek(long int position);
+        void                            seek(gint64 position);
         void                            draw( ofPoint _pos, float _width = -1, float _height = -1 );
         void                            drawSubsection( float _x, float _y, float _w, float _h, float _sx, float _sy );
         void                            loop( bool _loop );

--- a/src/ofxGstVideoSyncPlayer.h
+++ b/src/ofxGstVideoSyncPlayer.h
@@ -56,6 +56,7 @@ class ofxGstVideoSyncPlayer{
 
         void                            sendPauseMsg();
         void                            sendPlayMsg();
+        void                            sendSeekMsg(gint64 newPosition);
         void                            sendLoopMsg();
         void                            sendEosMsg();
 

--- a/src/ofxGstVideoSyncPlayer.h
+++ b/src/ofxGstVideoSyncPlayer.h
@@ -22,6 +22,7 @@ class ofxGstVideoSyncPlayer{
         bool                            load( std::string _path );
         void                            play();
         void                            update();
+        void                            seek(long int position);
         void                            draw( ofPoint _pos, float _width = -1, float _height = -1 );
         void                            drawSubsection( float _x, float _y, float _w, float _h, float _sx, float _sy );
         void                            loop( bool _loop );
@@ -34,7 +35,7 @@ class ofxGstVideoSyncPlayer{
         bool                            isMovieEnded();
         bool                            isMaster();
         void                            exit(ofEventArgs & args);
-        void                            setPixelFormat( const ofPixelFormat & _pixelFormat ); 
+        void                            setPixelFormat( const ofPixelFormat & _pixelFormat );
         const Clients&                  getConnectedClients();
     protected:
 
@@ -45,7 +46,7 @@ class ofxGstVideoSyncPlayer{
         bool                            m_isMaster;         ///> Is the master?
         bool                            m_initialized;      ///> If the player initialized properly ??
     private:
-        
+
         void                            setMasterClock();
         void                            setClientClock( GstClockTime _baseTime );
 

--- a/src/ofxGstVideoSyncPlayer.h
+++ b/src/ofxGstVideoSyncPlayer.h
@@ -23,6 +23,10 @@ class ofxGstVideoSyncPlayer{
         void                            play();
         void                            update();
         void                            seek(gint64 position);
+        gint64                          getPosition();
+        unsigned long int               getPositionMilliseconds();
+        gint64                          getDuration();
+        unsigned long int               getDurationMilliseconds();
         void                            draw( ofPoint _pos, float _width = -1, float _height = -1 );
         void                            drawSubsection( float _x, float _y, float _w, float _h, float _sx, float _sy );
         void                            loop( bool _loop );


### PR DESCRIPTION
Tested and appears to work well.

This will allow a player to jump to a position specified in milliseconds. Works best (quickest) when no inter frame compression is used, or where keyframes have been set manually to target jump points (ffmpeg ffmpeg force_key_frames).